### PR TITLE
feat: implement user language setting and save logic

### DIFF
--- a/app/src/main/java/com/timor/kidsstory/data/repository/UserPreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/repository/UserPreferenceRepositoryImpl.kt
@@ -1,0 +1,60 @@
+package com.timor.kidsstory.data.repository
+
+import android.content.Context
+import androidx.core.content.edit
+import com.timor.kidsstory.domain.model.UserPreference
+import com.timor.kidsstory.domain.repository.UserPreferenceRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * UserPreferenceRepository 인터페이스의 구현체
+ * SharedPreferences를 사용하여 사용자 설정을 저장하고 불러옴
+ */
+@Singleton
+class UserPreferenceRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : UserPreferenceRepository {
+
+    private val prefs = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    // 메모리에 캐싱된 설정
+    private val _userPreferencesFlow = MutableStateFlow(loadFromPreferences())
+
+    override fun getUserPreferences(): Flow<UserPreference> {
+        return _userPreferencesFlow.asStateFlow()
+    }
+
+    override suspend fun saveUserPreferences(userPreference: UserPreference) {
+        // SharedPreferences에 저장
+        prefs.edit {
+            putString(KEY_LANGUAGE, userPreference.languageCode)
+        }
+
+        // 메모리 캐시 업데이트
+        _userPreferencesFlow.value = userPreference
+    }
+
+    override suspend fun updateLanguage(languageCode: String) {
+        val currentPrefs = _userPreferencesFlow.value
+        val newPrefs = currentPrefs.copy(languageCode = languageCode)
+        saveUserPreferences(newPrefs)
+    }
+
+    // SharedPreferences에서 설정 로드
+    private fun loadFromPreferences(): UserPreference {
+        return UserPreference(
+            languageCode = prefs.getString(KEY_LANGUAGE, DEFAULT_LANGUAGE) ?: DEFAULT_LANGUAGE
+        )
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "tetum_dreams_preferences"
+        private const val KEY_LANGUAGE = "language_code"
+        private const val DEFAULT_LANGUAGE = "en-ph"
+    }
+}

--- a/app/src/main/java/com/timor/kidsstory/di/RepositoryModule.kt
+++ b/app/src/main/java/com/timor/kidsstory/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.timor.kidsstory.di
 
 import com.timor.kidsstory.data.repository.BookRepositoryImpl
+import com.timor.kidsstory.data.repository.UserPreferenceRepositoryImpl
 import com.timor.kidsstory.domain.repository.BookRepository
+import com.timor.kidsstory.domain.repository.UserPreferenceRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,4 +19,10 @@ abstract class RepositoryModule {
     abstract fun bindBookRepository(
         bookRepositoryImpl: BookRepositoryImpl
     ): BookRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindUserPreferenceRepository(
+        userPreferenceRepositoryImpl: UserPreferenceRepositoryImpl
+    ): UserPreferenceRepository
 }

--- a/app/src/main/java/com/timor/kidsstory/domain/model/UserPreference.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/model/UserPreference.kt
@@ -1,0 +1,9 @@
+package com.timor.kidsstory.domain.model
+
+/**
+ * 사용자 설정을 위한 도메인 모델
+ * 모든 사용자 설정을 담고 있는 데이터 클래스
+ */
+data class UserPreference(
+    val languageCode: String = "en-ph", // 기본 언어 코드
+)

--- a/app/src/main/java/com/timor/kidsstory/domain/repository/UserPreferenceRepository.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/repository/UserPreferenceRepository.kt
@@ -1,0 +1,21 @@
+package com.timor.kidsstory.domain.repository
+
+import com.timor.kidsstory.domain.model.UserPreference
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * 사용자 설정 관련 저장소 인터페이스
+ */
+interface UserPreferenceRepository {
+
+
+    // 저장된 사용자 설정을 Flow로 제공
+    // 설정이 변경될 때마다 Flow가 새로운 값을 방출
+    fun getUserPreferences(): Flow<UserPreference>
+
+    // 사용자 설정 전체 저장
+    suspend fun saveUserPreferences(userPreference: UserPreference)
+
+    // 언어 코드만 업데이트
+    suspend fun updateLanguage(languageCode: String)
+}

--- a/app/src/main/java/com/timor/kidsstory/domain/usecase/preference/GetUserPreferenceUseCase.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/usecase/preference/GetUserPreferenceUseCase.kt
@@ -1,0 +1,19 @@
+package com.timor.kidsstory.domain.usecase.preference
+
+import com.timor.kidsstory.domain.model.UserPreference
+import com.timor.kidsstory.domain.repository.UserPreferenceRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * 사용자 설정을 가져오는 UseCase
+ */
+class GetUserPreferenceUseCase @Inject constructor(
+    private val repository: UserPreferenceRepository
+) {
+
+    // 사용자 설정을 Flow로 제공
+    operator fun invoke(): Flow<UserPreference> {
+        return repository.getUserPreferences()
+    }
+}

--- a/app/src/main/java/com/timor/kidsstory/domain/usecase/preference/SaveUserPreferenceUseCase.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/usecase/preference/SaveUserPreferenceUseCase.kt
@@ -1,0 +1,24 @@
+package com.timor.kidsstory.domain.usecase.preference
+
+import com.timor.kidsstory.domain.model.UserPreference
+import com.timor.kidsstory.domain.repository.UserPreferenceRepository
+import javax.inject.Inject
+
+/**
+ * 사용자 설정을 저장하는 UseCase
+ */
+class SaveUserPreferenceUseCase @Inject constructor(
+    private val repository: UserPreferenceRepository
+) {
+
+    // 사용자 설정 전체 저장
+    suspend operator fun invoke(userPreference: UserPreference) {
+        repository.saveUserPreferences(userPreference)
+    }
+
+
+     //언어 설정만 업데이트
+    suspend fun updateLanguage(languageCode: String) {
+        repository.updateLanguage(languageCode)
+    }
+}

--- a/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/BookshelfViewModel.kt
+++ b/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/BookshelfViewModel.kt
@@ -6,11 +6,15 @@ import androidx.lifecycle.viewModelScope
 import com.timor.kidsstory.domain.model.Book
 import com.timor.kidsstory.domain.model.Language
 import com.timor.kidsstory.domain.usecase.book.GetBooksUseCase
+import com.timor.kidsstory.domain.usecase.preference.GetUserPreferenceUseCase
+import com.timor.kidsstory.domain.usecase.preference.SaveUserPreferenceUseCase
+import com.timor.kidsstory.domain.util.LanguageConstants
 import com.timor.kidsstory.presentation.bookshelf.model.BookCoverUiState
 import com.timor.kidsstory.presentation.bookshelf.model.BookshelfUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,7 +22,9 @@ import javax.inject.Inject
 // 책장 화면 뷰모델
 @HiltViewModel
 class BookshelfViewModel @Inject constructor(
-    private val getBooksUseCase: GetBooksUseCase
+    private val getBooksUseCase: GetBooksUseCase,
+    private val getUserPreferenceUseCase: GetUserPreferenceUseCase,
+    private val saveUserPreferenceUseCase: SaveUserPreferenceUseCase
 ) : ViewModel() {
     private val _state = MutableStateFlow(BookshelfUiState())
     val state = _state.asStateFlow()
@@ -27,7 +33,52 @@ class BookshelfViewModel @Inject constructor(
     private var bookList = listOf<Book>()
 
     init {
-        loadStories(_state.value.currentLanguage.code)
+        // 앱 시작 시 초기 데이터 로딩
+        loadInitialData()
+        // 이후 사용자 설정 변경 관찰
+        observeUserPreference()
+    }
+
+    private fun loadInitialData() {
+        viewModelScope.launch {
+            val preference = getUserPreferenceUseCase().first() // 현재 설정값 가져오기
+
+            val languageCode = if (preference.languageCode.isBlank()) {
+                LanguageConstants.DEFAULT_LANGUAGE.code
+            } else {
+                preference.languageCode
+            }
+
+            val language = LanguageConstants.SUPPORTED_LANGUAGES.find {
+                it.code == languageCode
+            } ?: LanguageConstants.DEFAULT_LANGUAGE
+
+            _state.update { it.copy(currentLanguage = language) }
+            loadStories(language.code)
+        }
+    }
+
+    private fun observeUserPreference() {
+        viewModelScope.launch {
+            getUserPreferenceUseCase().collect { preference ->
+                val languageCode = if (preference.languageCode.isBlank()) {
+                    // 저장된 언어가 없으면 기본 언어 사용
+                    LanguageConstants.DEFAULT_LANGUAGE.code
+                } else {
+                    preference.languageCode
+                }
+
+                val language = LanguageConstants.SUPPORTED_LANGUAGES.find {
+                    it.code == languageCode
+                } ?: LanguageConstants.DEFAULT_LANGUAGE
+
+                // 언어가 변경되었을 때만 상태 업데이트 및 책 로딩
+                if (language.code != _state.value.currentLanguage.code) {
+                    _state.update { it.copy(currentLanguage = language) }
+                    loadStories(language.code)
+                }
+            }
+        }
     }
 
     private fun loadStories(languageCode: String) {
@@ -47,9 +98,6 @@ class BookshelfViewModel @Inject constructor(
                         _state.update {
                             it.copy(
                                 books = books.map { book ->
-                                    Log.d("BookshelfViewModel", "Creating UI state for book: ${book.title}, ID: ${book.storyId}, Cover: ${book.coverImage}")
-
-                                    // 메타데이터에서 제공된 coverImage 필드는 파일명만 포함하므로 그대로 사용
                                     BookCoverUiState(
                                         imageUrl = book.coverImage,
                                         title = book.title,
@@ -108,9 +156,13 @@ class BookshelfViewModel @Inject constructor(
         Log.d("BookshelfViewModel", "Changing language to: ${language.code}")
 
         if (language.code != _state.value.currentLanguage.code) {
-            _state.update { it.copy(currentLanguage = language, showLanguageDialog = false) }
-            // 언어가 변경되면 해당 언어로 책 목록을 새로 로드
-            loadStories(language.code)
+            // 다이얼로그 닫기
+            _state.update { it.copy(showLanguageDialog = false) }
+
+            // 선택한 언어를 저장
+            viewModelScope.launch {
+                saveUserPreferenceUseCase.updateLanguage(language.code)
+            }
         } else {
             _state.update { it.copy(showLanguageDialog = false) }
         }


### PR DESCRIPTION
## 변경 내용
- UserPreference 도메인 모델 추가
- UserPreferenceRepository 인터페이스 및 구현체 추가
- 사용자 설정 저장 및 불러오기 UseCase 구현
- 앱 시작 시 저장된 언어 설정 적용
- 언어 변경 시 설정 저장 및 책 목록 갱신

## 휴먼테스트
- 앱 최초 실행 시 기본 언어(영어)로 책 목록 로딩 확인함
- 언어 변경 후 앱 재실행 시 선택한 언어 유지 확인함
- 언어 변경 시 책 목록이 올바르게 갱신되는지 확인함