### PR TITLE
refactor: unify page model

### DIFF
--- a/app/src/main/java/com/timor/kidsstory/data/local/assets/AssetDataSource.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/local/assets/AssetDataSource.kt
@@ -92,10 +92,4 @@ class AssetDataSource @Inject constructor(
             Result.failure(e)
         }
     }
-
-    // 이미지 파일 경로 생성
-    fun getImagePath(storyId: String, imageFileName: String): String {
-        val baseId = storyId.split("_").firstOrNull() ?: storyId
-        return "images/$baseId/$imageFileName"
-    }
 }

--- a/app/src/main/java/com/timor/kidsstory/data/mapper/BookMapper.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/mapper/BookMapper.kt
@@ -1,39 +1,38 @@
 package com.timor.kidsstory.data.mapper
 
-import android.util.Log
 import com.timor.kidsstory.data.dto.BookDto
-import com.timor.kidsstory.data.dto.TitlesDto
 import com.timor.kidsstory.domain.model.Book
 
 object BookMapper {
-    fun mapToDomain(dto: BookDto, language: String): Book {
-        val title = getLocalizedTitle(dto.titles, language)
 
-        // 기본 ID 추출 (예: 801_en-ph -> 801)
+    /**
+     * BookDto를 도메인 Book 객체로 변환
+     *
+     * @param dto 변환할 DTO
+     * @param language 사용할 언어 코드
+     * @param coverImagePath 커버 이미지 전체 경로
+     * @return 도메인 Book 객체
+     */
+    fun mapToDomain(dto: BookDto, language: String): Book {
+        // 기본 ID 추출
         val baseId = dto.storyId.split("_").firstOrNull() ?: dto.storyId
 
-        // 커버 이미지 파일명
-        val coverImage = dto.coverImage
-
-        Log.d("BookMapper", "Mapping book: storyId=${dto.storyId}, baseId=$baseId, title=$title, cover=$coverImage")
+        // 이미지 전체 경로 구성
+        val imageUrl = "file:///android_asset/images/${baseId}/${dto.coverImage}"
 
         return Book(
-            storyId = dto.storyId, // 원래 storyId 유지 (예: 801_en-ph)
-            title = title,
-            coverImage = coverImage, // 메타데이터에서 제공된 파일명 그대로 사용
+            storyId = dto.storyId,
+            title = when {
+                language.startsWith("ko") -> dto.titles.ko
+                language.startsWith("tet") -> dto.titles.tet
+                else -> dto.titles.en
+            },
+            coverImage = imageUrl,  // 절대 경로를 포함한 이미지 URL
             level = dto.level,
             category = dto.category,
             pageCount = dto.pageCount,
             isDownloaded = true,
             isBookmarked = false
         )
-    }
-
-    private fun getLocalizedTitle(titles: TitlesDto, language: String): String {
-        return when {
-            language.startsWith("ko") -> titles.ko
-            language.startsWith("tet") -> titles.tet
-            else -> titles.en
-        }
     }
 }

--- a/app/src/main/java/com/timor/kidsstory/data/mapper/PageMapper.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/mapper/PageMapper.kt
@@ -1,23 +1,35 @@
 package com.timor.kidsstory.data.mapper
 
-import android.util.Log
 import com.timor.kidsstory.data.dto.PageDto
 import com.timor.kidsstory.domain.model.Page
 
 object PageMapper {
-    fun mapToDomain(dto: PageDto, storyId: String): Page {
-        // 기본 ID 추출 (예: 801_en-ph -> 801)
-        val baseId = storyId.split("_").firstOrNull() ?: storyId
 
-        // 페이지 번호에 따라 적절한 이미지 파일명 결정
-        val imageFileName = "book_${baseId}_page_${dto.pageNumber}.jpg"
-
-        Log.d("PageMapper", "Mapping page ${dto.pageNumber} for story $storyId, image: $imageFileName")
+    /**
+     * PageDto 리스트를 도메인 Page 리스트로 변환
+     *
+     * @param pageDtos 변환할 DTO 리스트
+     * @param imagePathProvider 각 페이지에 대한 이미지 경로를 제공하는 함수
+     * @param totalPages 전체 페이지 수
+     * @return 도메인 Page 객체 리스트
+     */
+    fun mapToDomain(pageDto: PageDto, storyBaseId: String): Page {
+        // 이미지 파일명 생성
+        val imageFileName = "book_${storyBaseId}_page_${pageDto.pageNumber}.jpg"
+        val imageUrl = "file:///android_asset/images/$storyBaseId/$imageFileName"
 
         return Page(
-            pageNumber = dto.pageNumber,
-            imageFileName = imageFileName,
-            storyTexts = dto.texts
+            pageNumber = pageDto.pageNumber,
+            imageUrl = imageUrl,
+            texts = pageDto.texts
         )
+    }
+
+    // 페이지 리스트에 totalPages 정보 추가
+    fun addTotalPagesInfo(pages: List<Page>): List<Page> {
+        val totalPages = pages.size
+        return pages.map { page ->
+            page.copy(totalPages = totalPages)
+        }
     }
 }

--- a/app/src/main/java/com/timor/kidsstory/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/repository/BookRepositoryImpl.kt
@@ -30,6 +30,8 @@ class BookRepositoryImpl @Inject constructor(
                 }
 
                 Log.d("BookRepositoryImpl", "Found ${filteredBooks.size} books for language $language")
+
+                // BookMapper가 내부적으로 이미지 경로를 처리
                 filteredBooks.map { BookMapper.mapToDomain(it, language) }
             }
         } catch (e: Exception) {
@@ -39,7 +41,7 @@ class BookRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getBookById(storyId: String, language: String): Result<Book?> {
-        // 입력받은 storyId에서 기본 ID 추출 (예: 801_en-ph -> 801)
+        // 입력받은 storyId에서 기본 ID 추출 (801_en-ph -> 801)
         val baseId = storyId.split("_").firstOrNull() ?: storyId
 
         Log.d("BookRepositoryImpl", "Getting book by ID: $baseId, full storyId: $storyId")
@@ -108,10 +110,17 @@ class BookRepositoryImpl @Inject constructor(
             val fullStoryId = "${baseId}_${languageCode}"
             Log.d("BookRepositoryImpl", "Loading pages for full story ID: $fullStoryId")
 
-            assetDataSource.loadBookPages(fullStoryId, language).map { response ->
-                val pages = response.pages.map { PageMapper.mapToDomain(it, baseId) }
-                Log.d("BookRepositoryImpl", "Loaded ${pages.size} pages for book: $baseId")
-                pages
+            // 페이지 로드 및 매핑
+            val pagesResult = assetDataSource.loadBookPages(fullStoryId, language)
+
+            pagesResult.map { response ->
+                // 개별 페이지 매핑
+                val mappedPages = response.pages.map { pageDto ->
+                    PageMapper.mapToDomain(pageDto, baseId)
+                }.sortedBy { it.pageNumber }
+
+                // totalPages 정보 추가
+                PageMapper.addTotalPagesInfo(mappedPages)
             }
         } catch (e: Exception) {
             Log.e("BookRepositoryImpl", "Error getting book pages", e)

--- a/app/src/main/java/com/timor/kidsstory/domain/model/Page.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/model/Page.kt
@@ -3,6 +3,12 @@ package com.timor.kidsstory.domain.model
 // 페이지 도메인 모델
 data class Page(
     val pageNumber: Int,
-    val imageFileName: String,
-    val storyTexts: List<String>  // span id별 텍스트 목록
-)
+    val imageUrl: String,   // 전체 이미지 경로를 포함
+    val texts: List<String>, // 페이지 내 텍스트 목록
+    val totalPages: Int = 0  // 전체 페이지 수 (컬렉션의 일부로 사용될 때 선택적)
+) {
+    // 편의 메서드
+    val pageDisplay: String get() = "${pageNumber + 1}/$totalPages"
+    val isFirstPage: Boolean get() = pageNumber == 0
+    val isLastPage: Boolean get() = pageNumber == totalPages - 1
+}

--- a/app/src/main/java/com/timor/kidsstory/domain/model/PageDetail.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/model/PageDetail.kt
@@ -1,8 +1,0 @@
-package com.timor.kidsstory.domain.model
-
-// 페이지 상세 정보 도메인 모델
-data class PageDetail(
-    val imageUrl: String,
-    val texts: List<String>,
-    val pageNumber: Int
-)

--- a/app/src/main/java/com/timor/kidsstory/domain/model/StoryDetail.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/model/StoryDetail.kt
@@ -1,7 +1,0 @@
-package com.timor.kidsstory.domain.model
-
-// 스토리 상세 정보 도메인 모델
-data class StoryDetail(
-    val currentPage: Int,
-    val pages: List<PageDetail>
-)

--- a/app/src/main/java/com/timor/kidsstory/domain/usecase/book/GetBookDetailUseCase.kt
+++ b/app/src/main/java/com/timor/kidsstory/domain/usecase/book/GetBookDetailUseCase.kt
@@ -1,62 +1,30 @@
 package com.timor.kidsstory.domain.usecase.book
 
 import android.util.Log
-import com.timor.kidsstory.domain.model.PageDetail
-import com.timor.kidsstory.domain.model.StoryDetail
+import com.timor.kidsstory.domain.model.Page
 import com.timor.kidsstory.domain.repository.BookRepository
+import com.timor.kidsstory.domain.repository.UserPreferenceRepository
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class GetBookDetailUseCase @Inject constructor(
-    private val bookRepository: BookRepository
+    private val bookRepository: BookRepository,
+    private val userPreferenceRepository: UserPreferenceRepository
 ) {
-    suspend operator fun invoke(storyId: String): Result<StoryDetail> {
-        // 기본 언어 코드 설정 (나중에 언어 선택 기능 구현 시 변경 예정)
-        val defaultLanguage = "en-ph"
+    suspend operator fun invoke(storyId: String): Result<List<Page>> {
+        try {
+            // 사용자 설정에서 언어 가져오기
+            val userPreference = userPreferenceRepository.getUserPreferences().first()
+            val language = userPreference.languageCode.ifEmpty { "en-ph" }
 
-        // ID에서 기본 부분 추출 (예: 801_en-ph -> 801)
-        val baseId = storyId.split("_").firstOrNull() ?: storyId
+            Log.d("GetBookDetailUseCase", "Loading book: $storyId with language: $language")
 
-        Log.d("GetBookDetailUseCase", "Loading book: $baseId with language: $defaultLanguage")
+            // 책 페이지 가져오기
+            return bookRepository.getBookPages(storyId, language)
 
-        val bookResult = bookRepository.getBookById(baseId, defaultLanguage)
-        if (bookResult.isFailure) {
-            val error = bookResult.exceptionOrNull()
-            Log.e("GetBookDetailUseCase", "Failed to get book: ${error?.message}")
-            return Result.failure(error ?: Exception("책을 찾을 수 없습니다"))
+        } catch (e: Exception) {
+            Log.e("GetBookDetailUseCase", "Error in GetBookDetailUseCase", e)
+            return Result.failure(e)
         }
-
-        val book = bookResult.getOrNull() ?: return Result.failure(Exception("책을 찾을 수 없습니다"))
-        Log.d("GetBookDetailUseCase", "Book found: ${book.title}")
-
-        val pagesResult = bookRepository.getBookPages(baseId, defaultLanguage)
-        if (pagesResult.isFailure) {
-            val error = pagesResult.exceptionOrNull()
-            Log.e("GetBookDetailUseCase", "Failed to get pages: ${error?.message}")
-            return Result.failure(error ?: Exception("페이지를 불러올 수 없습니다"))
-        }
-
-        val pages = pagesResult.getOrNull() ?: emptyList()
-        Log.d("GetBookDetailUseCase", "Loaded ${pages.size} pages")
-
-        if (pages.isEmpty()) {
-            return Result.failure(Exception("이 책에는 페이지가 없습니다"))
-        }
-
-        return Result.success(
-            StoryDetail(
-                currentPage = 0,
-                pages = pages.map { page ->
-                    val imageFileName = page.imageFileName
-                    Log.d("GetBookDetailUseCase", "Creating page detail, image: $imageFileName")
-
-                    PageDetail(
-                        // 이미지 경로는 기본 ID를 포함해야 함 (예: "801/book_801_page_1.jpg")
-                        imageUrl = "$baseId/$imageFileName",
-                        texts = page.storyTexts,
-                        pageNumber = page.pageNumber
-                    )
-                }
-            )
-        )
     }
 }

--- a/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/BookshelfViewModel.kt
+++ b/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/BookshelfViewModel.kt
@@ -99,7 +99,7 @@ class BookshelfViewModel @Inject constructor(
                             it.copy(
                                 books = books.map { book ->
                                     BookCoverUiState(
-                                        imageUrl = book.coverImage,
+                                        imageUrl = book.coverImage, // 이미 정확한 경로 포함
                                         title = book.title,
                                         storyId = book.storyId
                                     )

--- a/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/components/BookCover.kt
+++ b/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/components/BookCover.kt
@@ -1,10 +1,7 @@
 package com.timor.kidsstory.presentation.bookshelf.components
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -15,20 +12,11 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.timor.kidsstory.presentation.bookshelf.model.BookCoverUiState
 
-// 책 표지 UI 컴포넌트
 @Composable
 fun BookCover(
     state: BookCoverUiState,
     onClick: () -> Unit,
 ) {
-    // storyId에서 기본 ID 추출 (예: 801_en-ph -> 801)
-    val baseId = state.storyId.split("_").firstOrNull() ?: state.storyId
-
-    // 메타데이터의 coverImage 필드에는 파일명만 있으므로 경로 구성
-    val imagePath = "images/$baseId/${state.imageUrl}"
-
-    Log.d("BookCover", "Loading cover image: $imagePath for storyId: ${state.storyId}")
-
     Card(
         modifier = Modifier
             .width(180.dp)
@@ -36,10 +24,9 @@ fun BookCover(
         elevation = CardDefaults.cardElevation(4.dp)
     ) {
         AsyncImage(
-            model = "file:///android_asset/$imagePath",
+            model = state.imageUrl,
             contentDescription = state.title,
-            modifier = Modifier
-                .fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Fit
         )
     }

--- a/app/src/main/java/com/timor/kidsstory/presentation/reader/ReaderViewModel.kt
+++ b/app/src/main/java/com/timor/kidsstory/presentation/reader/ReaderViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.timor.kidsstory.domain.model.Page
 import com.timor.kidsstory.domain.usecase.book.GetBookDetailUseCase
 import com.timor.kidsstory.domain.util.TextToSpeechHelper
 import com.timor.kidsstory.presentation.reader.model.PageUiState
@@ -15,7 +16,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-// 읽기 화면 뷰모델
 @HiltViewModel
 class ReaderViewModel @Inject constructor(
     private val getBookDetailUseCase: GetBookDetailUseCase,
@@ -30,12 +30,13 @@ class ReaderViewModel @Inject constructor(
 
     private val storyId: String = savedStateHandle.get<String>("storyId") ?: ""
 
+    private var pages: List<Page> = emptyList()
+
     init {
         Log.d("ReaderViewModel", "Initializing with storyId: $storyId")
 
         if (storyId.isNotEmpty()) {
             loadStory(storyId)
-
         } else {
             Log.e("ReaderViewModel", "No storyId provided")
             _state.update { it.copy(error = "책 ID가 제공되지 않았습니다") }
@@ -59,19 +60,11 @@ class ReaderViewModel @Inject constructor(
             _state.update { it.copy(isLoading = true, error = null) }
 
             try {
-                // 기본 ID 추출 (예: 801_en-ph -> 801)
-                val baseId = storyId.split("_").firstOrNull() ?: storyId
-                Log.d("ReaderViewModel", "Loading story with base ID: $baseId")
-
-                // storyId 그대로 전달 (원본 ID 유지)
                 getBookDetailUseCase(storyId).fold(
-                    onSuccess = { storyDetail ->
-                        Log.d(
-                            "ReaderViewModel",
-                            "Story loaded with ${storyDetail.pages.size} pages"
-                        )
+                    onSuccess = { loadedPages ->
+                        Log.d("ReaderViewModel", "Story loaded with ${loadedPages.size} pages")
 
-                        if (storyDetail.pages.isEmpty()) {
+                        if (loadedPages.isEmpty()) {
                             Log.e("ReaderViewModel", "Story has no pages")
                             _state.update {
                                 it.copy(
@@ -82,15 +75,18 @@ class ReaderViewModel @Inject constructor(
                             return@fold
                         }
 
+                        // 페이지 정보 저장
+                        pages = loadedPages
+
                         _state.update {
                             it.copy(
                                 currentPage = 0,
-                                pages = storyDetail.pages.map { page ->
+                                pages = loadedPages.map { page ->
                                     PageUiState(
                                         imageUrl = page.imageUrl,
                                         texts = page.texts,
                                         pageNumber = page.pageNumber + 1,
-                                        totalPages = storyDetail.pages.size
+                                        totalPages = page.totalPages
                                     )
                                 },
                                 isLoading = false,

--- a/app/src/main/java/com/timor/kidsstory/presentation/reader/components/PageImageSection.kt
+++ b/app/src/main/java/com/timor/kidsstory/presentation/reader/components/PageImageSection.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.timor.kidsstory.presentation.reader.model.ImageSectionUiState
 
-// 읽기 화면 하위 컴포넌트들
 @Composable
 fun PageImageSection(
     state: ImageSectionUiState,
@@ -26,7 +25,7 @@ fun PageImageSection(
 ) {
     Box(modifier = modifier.fillMaxHeight()) {
         AsyncImage(
-            model = "file:///android_asset/images/${state.imageUrl}",
+            model = state.imageUrl,
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize()


### PR DESCRIPTION
## 리팩토링 작업 내용
### 도메인 모델 통합
- 기존에 분리되어 있던 Page, PageDetail, StoryDetail 모델을 단일 Page 모델로 통합
- 페이지 번호, 이미지 URL, 텍스트 목록, 전체 페이지 수 등 필요한 모든 정보를 하나의 모델에 포함시킴
- 페이지 표시 정보(pageDisplay)와 같은 편의 메서드를 추가하여 UI 구성 시 쉽게 접근할 수 있도록 함.

### 매퍼 클래스 개선
- 이미지 경로 생성 로직을 BookMapper와 PageMapper 클래스 내부로 캡슐화.
- 각 매퍼 클래스에서 일관된 패턴으로 이미지 경로를 구성.
- PageMapper에 totalPages 정보를 추가하는 로직을 구현하여 페이지 컬렉션 관련 정보를 쉽게 처리할 수 있게 함.

### Repository 구현 수정
- BookRepositoryImpl의 모든 메서드를 통합된 Page 모델과 함께 작동하도록 수정
- getBookPages 메서드의 반환 타입 문제를 해결하고 정확한 페이지 목록을 반환하도록 수정.
- 이미지 경로 생성 로직을 제거하고 대신 매퍼 클래스의 기능을 활용하도록 변경.

### UseCase 및 ViewModel 수정
- GetBookDetailUseCase를 통합된 Page 모델과 함께 작동하도록 수정.
- ReaderViewModel에서 도메인 모델 변경에 맞게 데이터 처리 로직을 업데이트.
- BookshelfViewModel이 모델에서 제공하는 전체 이미지 경로를 사용하도록 조정.
- 이미지 경로 구성 로직을 뷰모델에서 제거하여 로직을 단순화

### UI 컴포넌트 수정
- UI 컴포넌트에서 이미지 경로 구성 로직을 제거
- PageImageSection이 모델에서 직접 이미지 URL을 사용하도록 단순화.
- BookCover 컴포넌트가 Book 모델에서 전체 이미지 경로를 사용하도록 업데이트.