### PR TITLE
bugfix: 카테고리 필터링 기능 개선 및 버그 수정

### DIFF
--- a/app/src/main/assets/metadata/stories-metadata.json
+++ b/app/src/main/assets/metadata/stories-metadata.json
@@ -14,11 +14,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 5477591,
     "coverImage": "cover_801_en.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 28
   },
@@ -37,11 +37,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 5085546,
     "coverImage": "cover_801_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 28
   },
@@ -60,11 +60,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 5085546,
     "coverImage": "cover_801_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 28
   },
@@ -83,11 +83,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "life"
     ],
     "size": 5061122,
     "coverImage": "cover_802_en.jpg",
-    "category": "FOLKTALE",
+    "category": "LIFE",
     "region": "Asia",
     "estimatedReadTime": 30
   },
@@ -106,11 +106,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "life"
     ],
     "size": 4807529,
     "coverImage": "cover_802_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "LIFE",
     "region": "Asia",
     "estimatedReadTime": 30
   },
@@ -129,11 +129,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "life"
     ],
     "size": 4807529,
     "coverImage": "cover_802_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "LIFE",
     "region": "Asia",
     "estimatedReadTime": 30
   },
@@ -152,11 +152,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 3606499,
     "coverImage": "cover_806_en.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 22
   },
@@ -175,11 +175,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 3570166,
     "coverImage": "cover_806_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 22
   },
@@ -198,11 +198,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 3570166,
     "coverImage": "cover_806_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 22
   },
@@ -221,11 +221,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 4676914,
     "coverImage": "cover_807_en.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 32
   },
@@ -244,11 +244,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 4392985,
     "coverImage": "cover_807_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 32
   },
@@ -267,11 +267,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 4392985,
     "coverImage": "cover_807_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 32
   },
@@ -290,11 +290,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 5429485,
     "coverImage": "cover_810_en.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 26
   },
@@ -313,11 +313,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 5315833,
     "coverImage": "cover_810_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 26
   },
@@ -336,11 +336,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "legend"
     ],
     "size": 5315833,
     "coverImage": "cover_810_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "LEGEND",
     "region": "Asia",
     "estimatedReadTime": 26
   },
@@ -359,11 +359,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 6253257,
     "coverImage": "cover_816_en.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 26
   },
@@ -382,11 +382,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 6020670,
     "coverImage": "cover_816_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 26
   },
@@ -405,11 +405,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 6020670,
     "coverImage": "cover_816_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 26
   },
@@ -497,11 +497,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 5082017,
     "coverImage": "cover_819_en.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 28
   },
@@ -520,11 +520,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 4891603,
     "coverImage": "cover_819_kr.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 28
   },
@@ -543,11 +543,11 @@
     "version": "1.0.0",
     "tags": [
       "story",
-      "folktale"
+      "culture"
     ],
     "size": 4891603,
     "coverImage": "cover_819_tet.jpg",
-    "category": "FOLKTALE",
+    "category": "CULTURE",
     "region": "Asia",
     "estimatedReadTime": 28
   }

--- a/app/src/main/java/com/timor/kidsstory/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/local/database/AppDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.timor.kidsstory.data.local.database.dao.AvailableBooksDao
 import com.timor.kidsstory.data.local.database.dao.DownloadedBooksDao
 import com.timor.kidsstory.data.local.database.entity.AvailableBookEntity
@@ -12,7 +14,7 @@ import com.timor.kidsstory.data.local.database.entity.DownloadedBookEntity
 
 @Database(
     entities = [DownloadedBookEntity::class, AvailableBookEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -24,6 +26,14 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        // 버전 2에서 버전 3으로의 마이그레이션 추가
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // DownloadedBookEntity에 category 컬럼 추가
+                database.execSQL("ALTER TABLE downloaded_books ADD COLUMN category TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -31,6 +41,9 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "storybook_database"
                 )
+                    // 버전 2에서 3으로 마이그레이션을 추가
+                    .addMigrations(MIGRATION_2_3)
+                    // 다른 버전 변경에 대해서는 fallbackToDestructiveMigration 유지
                     .fallbackToDestructiveMigration()
                     .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/timor/kidsstory/data/local/database/entity/DownloadedBookEntity.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/local/database/entity/DownloadedBookEntity.kt
@@ -17,5 +17,6 @@ data class DownloadedBookEntity(
     val coverImagePath: String,
     val contentJsonPath: String,
     val hasImages: Boolean,
-    val downloadDate: Long = System.currentTimeMillis()
+    val downloadDate: Long = System.currentTimeMillis(),
+    val category: String = ""
 )

--- a/app/src/main/java/com/timor/kidsstory/data/remote/BookDownloader.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/remote/BookDownloader.kt
@@ -57,7 +57,7 @@ class BookDownloader @Inject constructor(
                             title = existingBook.title,
                             coverImage = existingBook.coverImagePath,
                             level = 1,
-                            category = "",
+                            category = existingBook.category, // 카테고리 정보 사용
                             pageCount = 0,
                             isDownloaded = true,
                             isBookmarked = false
@@ -77,6 +77,8 @@ class BookDownloader @Inject constructor(
             val downloadUrl = remoteBook.download[langKey] ?: throw IllegalArgumentException("No download URL for language: $langKey")
             val coverUrl = remoteBook.cover[langKey] ?: throw IllegalArgumentException("No cover URL for language: $langKey")
             val title = remoteBook.title[langKey] ?: remoteBook.title["en"] ?: "Book ${remoteBook.id}"
+            // 카테고리 정보 추출
+            val category = remoteBook.category
 
             // 책 저장 디렉토리 생성
             val bookDir = File(booksDir, "${remoteBook.id}").apply { mkdirs() }
@@ -134,7 +136,8 @@ class BookDownloader @Inject constructor(
                 coverImagePath = coverFile.absolutePath,
                 contentJsonPath = jsonFile.absolutePath,
                 hasImages = imagesDownloaded || imagesExist,
-                downloadDate = System.currentTimeMillis()
+                downloadDate = System.currentTimeMillis(),
+                category = category // 카테고리 정보 추가
             )
 
             downloadedBooksDao.insertDownloadedBook(bookEntity)
@@ -146,7 +149,7 @@ class BookDownloader @Inject constructor(
                 title = bookEntity.title,
                 coverImage = bookEntity.coverImagePath,
                 level = 1,  // 임의 값
-                category = "", // 임의 값
+                category = category, // 카테고리 정보 사용
                 pageCount = 0, // 초기값
                 isDownloaded = true,
                 isBookmarked = false

--- a/app/src/main/java/com/timor/kidsstory/data/remote/model/GithubMetadata.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/remote/model/GithubMetadata.kt
@@ -27,5 +27,6 @@ data class RemoteBook(
     val cover: Map<String, String>,
     val download: Map<String, String>,
     val images: String,
-    val languages: List<String>
+    val languages: List<String>,
+    val category: String = ""
 )

--- a/app/src/main/java/com/timor/kidsstory/data/remote/worker/DownloadWorker.kt
+++ b/app/src/main/java/com/timor/kidsstory/data/remote/worker/DownloadWorker.kt
@@ -44,8 +44,11 @@ class DownloadWorker @AssistedInject constructor(
 
             Log.d(TAG, "Starting download for book ID: $bookId, language: $language")
 
+            // 카테고리 정보가 포함된 RemoteBook 객체 디코딩
             val remoteBook = json.decodeFromString<RemoteBook>(metadataJson)
 
+            // bookDownloader.downloadBook 메서드에 remoteBook을 그대로 전달
+            // (BookDownloader 클래스는 RemoteBook에서 category 필드를 처리하도록 수정 필요)
             val result = bookDownloader.downloadBook(remoteBook, language)
 
             return if (result.isSuccess) {

--- a/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/BookshelfViewModel.kt
+++ b/app/src/main/java/com/timor/kidsstory/presentation/bookshelf/BookshelfViewModel.kt
@@ -204,13 +204,24 @@ class BookshelfViewModel @Inject constructor(
                         // 전체 책 목록 (로컬 + 다운로드)
                         val combinedBooks = localBooksWithDownloadStatus + newDownloadedBooks
 
+                        // 현재 필터 상태 확인
+                        val currentFilter = _state.value.filterBarState.selectedFilter
+                        val shouldApplyFilters = currentFilter != FilterBarCategory.All
+
                         // UI 상태 업데이트
                         _state.update {
-                            it.copy(
-                                books = combinedBooks,
-                                filteredBooks = combinedBooks,
-                                isLoading = false
-                            )
+                            if (shouldApplyFilters) {
+                                // 현재 필터 상태가 있으면 books만 업데이트
+                                it.copy(books = combinedBooks, isLoading = false)
+                            } else {
+                                // 필터 상태가 ALL이면 filteredBooks도 함께 업데이트
+                                it.copy(books = combinedBooks, filteredBooks = combinedBooks, isLoading = false)
+                            }
+                        }
+
+                        // 필터링이 필요한 경우 applyFilters 호출
+                        if (shouldApplyFilters) {
+                            applyFilters()
                         }
 
                         Log.d(
@@ -258,7 +269,7 @@ class BookshelfViewModel @Inject constructor(
                     title = entity.title,
                     coverImage = entity.coverImagePath,
                     level = 1,
-                    category = "",
+                    category = entity.category,
                     pageCount = 0,
                     isDownloaded = true,
                     isBookmarked = false
@@ -488,6 +499,7 @@ class BookshelfViewModel @Inject constructor(
 
                     val coverUrl = remoteBook.cover[langKey] ?: ""
                     val title = remoteBook.title[langKey] ?: "Book ${remoteBook.id}"
+                    val category = remoteBook.category
 
                     Log.d("BookshelfViewModel", "Processing book ${remoteBook.id}: $title, cover URL: $coverUrl")
 
@@ -504,7 +516,7 @@ class BookshelfViewModel @Inject constructor(
                                     title = title,
                                     coverImage = localCoverPath,
                                     level = 1,
-                                    category = "",
+                                    category = category,
                                     pageCount = 0,
                                     isDownloaded = false,  // 원격 책은 다운로드 필요
                                     isBookmarked = false
@@ -704,8 +716,12 @@ class BookshelfViewModel @Inject constructor(
                 FilterBarCategory.STAGE -> selectedStage?.let { book.level == (it.ordinal + 1) }
                     ?: true
 
-                FilterBarCategory.CATEGORY -> selectedCategory?.let { book.category == it.name }
-                    ?: true
+                FilterBarCategory.CATEGORY -> selectedCategory?.let {
+                    // 대소문자 무시하고 비교 또는 displayName도 함께 확인
+                    book.category.equals(it.name, ignoreCase = true) ||
+                            book.category.equals(it.displayName, ignoreCase = true)
+                } ?: true
+
                 else -> true // ALL일 경우 필터 적용 없음
             }
         }
@@ -966,7 +982,7 @@ class BookshelfViewModel @Inject constructor(
                             title = downloadedBookEntity.title,
                             coverImage = downloadedBookEntity.coverImagePath,
                             level = 1,
-                            category = "",
+                            category = downloadedBookEntity.category,
                             pageCount = 0,
                             isDownloaded = true,
                             isBookmarked = false


### PR DESCRIPTION
## 개요
원격 저장소 책 메타데이터에 카테고리 정보 추가하여 로컬 책, 다운로드 책 모두 카테고리 필터링 적용토록 함.

### 주요 변경 사항
- 1. 데이터 모델 개선
  - RemoteBook 및 DownloadedBookEntity에 카테고리 필드 추가
  - 데이터베이스 스키마 업데이트(v2 → v3)로 카테고리 정보 저장

- 2. 버그 수정
  - 다운로드된 책에 카테고리 정보 누락 수정: 다운로드된 책도 카테고리 정보가 포함되어 필터링에 반영됨
  - 언어 변경 시 필터 상태 유지: 언어 변경 후에도 이전 필터 상태가 유지되도록 개선
  - 카테고리 비교 시 대소문자 무시: 서로 다른 대소문자로 인한 필터링 문제 수정

- 3. 카테고리 분류 작업
  - 로컬 및 원격 메타데이터에 카테고리 정보 추가
  - 모든 책에 Legend, Folktale, Culture, Life 중 하나의 카테고리 부여


### 테스트 결과
  - 모든 카테고리 필터 정상 작동 확인
  - 다운로드된 책도 올바른 카테고리로 필터링 됨
  - 언어 변경 후에도 필터 상태가 유지되는 것 확인

### 관련 이슈

#64 